### PR TITLE
Add rollbar

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem 'jbuilder', '~> 2.5'
 gem 'activerecord-import'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
-
+gem 'rollbar'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,6 +264,7 @@ GEM
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    rollbar (2.22.1)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -401,6 +402,7 @@ DEPENDENCIES
   puma (~> 3.11)
   rails (~> 5.2.3)
   rails_12factor
+  rollbar
   rspec-html-matchers
   rspec-rails
   sass-rails (~> 5.0)

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -1,0 +1,10 @@
+Rollbar.configure do |config|
+  if Rails.env.production?
+    config.enabled = true
+    config.access_token = ENV["ROLLBAR_TOKEN"]
+  else
+    config.enabled = false
+  end
+
+  config.environment = ENV['ROLLBAR_ENV'].presence || Rails.env
+end


### PR DESCRIPTION
Currently I have no way of knowing what input is actually causing errors or unexpected behavior if I have any other users using the app. I've wrote some tests but in order to actually have a record of the things that do cause errors in production I need Rollbar.

- Add `rollbar` to Gemfile
- configure it with my token

